### PR TITLE
Implement offline multi-format ingestion and memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # docu-rag
 
-Simple RAG system skeleton for internal document QA.
+Simple RAG system skeleton for internal document QA. Documents stay on-premise and models run locally.
 
 ## Modules
 
-- `ingestion/` - download and preprocess documents.
-- `retrieval/` - simple vector store and search utilities.
-- `llm/` - prompt handling and model loading.
+- `ingestion/` - download and preprocess documents from SharePoint.
+- `retrieval/` - simple vector store and search utilities with reranking.
+- `llm/` - prompt handling and local model loading.
 - `memory/` - conversation history logging and search.
-- `api_server.py` - FastAPI application.
-- `ui/` - minimal chat frontend.
+- `api_server.py` - FastAPI application exposing `/query` and `/generate`.
+- `ui/` - minimal chat frontend with conversation view.

--- a/api_server.py
+++ b/api_server.py
@@ -1,15 +1,17 @@
 """Minimal FastAPI server for querying the RAG system."""
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
 from retrieval.search import Searcher
 from retrieval.vector_store import VectorStore
-from llm.generator import generate_answer
+from llm.generator import generate_with_citations
+from memory import memory_db
 
 app = FastAPI()
 store = VectorStore()
 searcher = Searcher(store)
+memory_db.init_db()
 
 
 class QueryRequest(BaseModel):
@@ -19,6 +21,43 @@ class QueryRequest(BaseModel):
 
 @app.post("/query")
 async def query(req: QueryRequest) -> dict:
-    docs = [r.text for r in searcher.search(req.question)]
-    answer = generate_answer(docs, req.question, model_name="dummy")
-    return {"answer": answer}
+    """Answer a user question and log the conversation."""
+
+    try:
+        results = searcher.search(req.question)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    records = [
+        {"text": r.text, "source": r.metadata.get("source", "")}
+        for r in results
+    ]
+
+    try:
+        resp = generate_with_citations(records, req.question, model_name="dummy")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    memory_db.log(req.user, "user", req.question)
+    memory_db.log(req.user, "assistant", resp["answer"])
+
+    return resp
+
+
+class GenerateRequest(BaseModel):
+    user: str
+    instruction: str
+
+
+@app.post("/generate")
+async def generate(req: GenerateRequest) -> dict:
+    """Generate a new document draft from instructions."""
+
+    memory_db.log(req.user, "user", req.instruction)
+    try:
+        resp = generate_with_citations([], req.instruction, model_name="dummy")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    memory_db.log(req.user, "assistant", resp["answer"])
+    return resp

--- a/ingestion/file_parsers.py
+++ b/ingestion/file_parsers.py
@@ -3,10 +3,62 @@
 from pathlib import Path
 from typing import Iterable
 
+from io import BytesIO
+
+try:
+    import docx
+    from openpyxl import load_workbook
+    import PyPDF2
+    from pptx import Presentation
+except Exception:  # pragma: no cover - optional dependencies
+    docx = None
+    load_workbook = None
+    PyPDF2 = None
+    Presentation = None
+
 
 def extract_text(file_path: Path) -> str:
-    """Extract text from a single document."""
-    raise NotImplementedError
+    """Extract text from a single document.
+
+    Supports .txt, .docx, .xlsx, .pdf and .pptx files.
+    """
+
+    if not file_path.exists():
+        raise FileNotFoundError(file_path)
+
+    suffix = file_path.suffix.lower()
+    try:
+        if suffix == ".txt":
+            return file_path.read_text(encoding="utf-8")
+        if suffix == ".docx" and docx:
+            doc = docx.Document(str(file_path))
+            return "\n".join(p.text for p in doc.paragraphs)
+        if suffix == ".xlsx" and load_workbook:
+            wb = load_workbook(file_path, read_only=True, data_only=True)
+            text_parts = []
+            for ws in wb.worksheets:
+                for row in ws.iter_rows(values_only=True):
+                    text_parts.append("\t".join(str(c) if c is not None else "" for c in row))
+            return "\n".join(text_parts)
+        if suffix == ".pdf" and PyPDF2:
+            text_parts = []
+            with open(file_path, "rb") as f:
+                reader = PyPDF2.PdfReader(f)
+                for page in reader.pages:
+                    text_parts.append(page.extract_text() or "")
+            return "\n".join(text_parts)
+        if suffix == ".pptx" and Presentation:
+            pres = Presentation(str(file_path))
+            text_runs = []
+            for slide in pres.slides:
+                for shape in slide.shapes:
+                    if hasattr(shape, "text"):
+                        text_runs.append(shape.text)
+            return "\n".join(text_runs)
+    except Exception as e:  # pragma: no cover - runtime errors
+        raise RuntimeError(f"Failed to extract text from {file_path}: {e}") from e
+
+    raise ValueError(f"Unsupported file type: {file_path}")
 
 
 def chunk_text(text: str, chunk_size: int = 500) -> Iterable[str]:

--- a/ingestion/index_updater.py
+++ b/ingestion/index_updater.py
@@ -19,8 +19,14 @@ class IndexUpdater:
     def ingest(self, doc_urls: Iterable[str]) -> None:
         """Download documents, preprocess, and add to vector store."""
         for url in doc_urls:
-            data = self.client.download_document(url)
-            text = extract_text(Path(url))  # placeholder
-            text = normalize_text(text)
-            for chunk in chunk_text(text):
-                self.store.add(text=chunk, metadata={"source": url})
+            try:
+                data = self.client.download_document(url)
+                tmp_path = Path("/tmp") / Path(url).name
+                tmp_path.write_bytes(data)
+                text = extract_text(tmp_path)
+                tmp_path.unlink(missing_ok=True)
+                text = normalize_text(text)
+                for chunk in chunk_text(text):
+                    self.store.add(text=chunk, metadata={"source": url})
+            except Exception as e:
+                print(f"Failed to ingest {url}: {e}")

--- a/ingestion/sharepoint_client.py
+++ b/ingestion/sharepoint_client.py
@@ -2,6 +2,8 @@
 
 from typing import List
 
+import time
+
 
 class SharePointClient:
     """Simple SharePoint API client skeleton."""
@@ -17,3 +19,18 @@ class SharePointClient:
     def download_document(self, url: str) -> bytes:
         """Download document content and return as bytes."""
         raise NotImplementedError
+
+    def watch_for_updates(self, callback, poll_interval: int = 60) -> None:
+        """Continuously poll for document updates and invoke callback."""
+
+        known = set(self.list_documents())
+        while True:
+            try:
+                current = set(self.list_documents())
+                added = current - known
+                if added:
+                    callback(list(added))
+                known = current
+                time.sleep(poll_interval)
+            except Exception as e:
+                print(f"SharePoint watch error: {e}")

--- a/llm/generator.py
+++ b/llm/generator.py
@@ -17,7 +17,18 @@ def build_prompt(context: str, question: str) -> str:
 
 
 def generate_answer(context_docs: List[str], question: str, model_name: str) -> str:
+    """Generate an answer from context documents."""
+
     model = load_model(model_name)
     prompt = build_prompt("\n".join(context_docs), question)
-    # placeholder inference
+    # placeholder inference using local model
     return f"[Model output for] {prompt}"
+
+
+def generate_with_citations(records: List[Dict[str, Any]], question: str, model_name: str) -> Dict[str, Any]:
+    """Generate answer and include source citations."""
+
+    docs = [r["text"] for r in records]
+    answer = generate_answer(docs, question, model_name)
+    sources = [r.get("source") for r in records if r.get("source")]
+    return {"answer": answer, "sources": sources}

--- a/memory/memory_db.py
+++ b/memory/memory_db.py
@@ -8,27 +8,36 @@ DB_PATH = Path("memory.db")
 
 
 def init_db() -> None:
+    """Initialize the history database if it does not exist."""
     conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    cur.execute(
-        "CREATE TABLE IF NOT EXISTS history (user TEXT, role TEXT, message TEXT)"
-    )
-    conn.commit()
-    conn.close()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS history (user TEXT, role TEXT, message TEXT)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def log(user: str, role: str, message: str) -> None:
+    """Persist a single conversation message."""
     conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    cur.execute("INSERT INTO history VALUES (?, ?, ?)", (user, role, message))
-    conn.commit()
-    conn.close()
+    try:
+        cur = conn.cursor()
+        cur.execute("INSERT INTO history VALUES (?, ?, ?)", (user, role, message))
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def fetch(user: str) -> Iterable[Tuple[str, str, str]]:
+    """Fetch conversation history for a user."""
     conn = sqlite3.connect(DB_PATH)
-    cur = conn.cursor()
-    cur.execute("SELECT * FROM history WHERE user = ?", (user,))
-    rows = cur.fetchall()
-    conn.close()
-    return rows
+    try:
+        cur = conn.cursor()
+        cur.execute("SELECT * FROM history WHERE user = ?", (user,))
+        rows = cur.fetchall()
+        return rows
+    finally:
+        conn.close()

--- a/retrieval/search.py
+++ b/retrieval/search.py
@@ -3,6 +3,7 @@
 from typing import List
 
 from .vector_store import VectorStore, VectorRecord
+from .ranker import rerank
 
 
 class Searcher:
@@ -13,7 +14,12 @@ class Searcher:
 
     def search(self, query: str, top_k: int = 3) -> List[VectorRecord]:
         vector = self._embed(query)
-        return self.store.query(vector, top_k=top_k)
+        try:
+            candidates = self.store.query(vector, top_k=top_k * 2)
+            ranked = rerank(candidates, query)
+            return ranked[:top_k]
+        except Exception as e:
+            raise RuntimeError(f"Search failed: {e}") from e
 
     def _embed(self, text: str) -> List[float]:
         return [0.0]

--- a/retrieval/vector_store.py
+++ b/retrieval/vector_store.py
@@ -18,11 +18,14 @@ class VectorStore:
         self.records: List[VectorRecord] = []
 
     def add(self, text: str, metadata: dict) -> None:
+        """Add a record to the store."""
         vector = self._embed(text)
         self.records.append(VectorRecord(text, vector, metadata))
 
     def query(self, vector: Sequence[float], top_k: int = 5) -> List[VectorRecord]:
         """Return top_k similar records (naive)."""
+        if top_k <= 0:
+            raise ValueError("top_k must be positive")
         return self.records[:top_k]
 
     def _embed(self, text: str) -> List[float]:

--- a/ui/app.js
+++ b/ui/app.js
@@ -1,10 +1,37 @@
 async function send() {
     const input = document.getElementById('input');
+    const chat = document.getElementById('chat');
+
     const resp = await fetch('/query', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({user: 'demo', question: input.value})
     });
     const data = await resp.json();
-    document.getElementById('chat').innerText = data.answer;
+
+    const userMsg = document.createElement('div');
+    userMsg.textContent = input.value;
+    userMsg.className = 'user';
+    chat.appendChild(userMsg);
+
+    const botMsg = document.createElement('div');
+    botMsg.textContent = data.answer;
+    botMsg.className = 'bot';
+    chat.appendChild(botMsg);
+
+    if (data.sources) {
+        const srcList = document.createElement('ul');
+        data.sources.forEach(s => {
+            const li = document.createElement('li');
+            const a = document.createElement('a');
+            a.href = s;
+            a.textContent = s;
+            li.appendChild(a);
+            srcList.appendChild(li);
+        });
+        chat.appendChild(srcList);
+    }
+
+    input.value = '';
+    chat.scrollTop = chat.scrollHeight;
 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -5,6 +5,11 @@
     <title>DocuRAG</title>
 </head>
 <body>
+    <style>
+        #chat { height: 300px; overflow-y: auto; border: 1px solid #ccc; padding: 10px; }
+        .user { font-weight: bold; }
+        .bot { margin-bottom: 10px; }
+    </style>
     <div id="chat"></div>
     <input id="input" type="text" />
     <button onclick="send()">Send</button>


### PR DESCRIPTION
## Summary
- support extracting text from docx, xlsx, pdf and pptx files
- use SQLite history and log interactions via the API
- return answers with citations and add draft generation endpoint
- improve vector search with reranking and error handling
- enhance chat UI to display conversation and sources

## Testing
- `python -m py_compile api_server.py ingestion/*.py llm/*.py memory/*.py retrieval/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6885fde7c7b48328a8104951703e51e1