### PR TITLE
Add simple hashed embedding RAG pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,16 @@ Simple RAG system skeleton for internal document QA. Documents stay on-premise a
 ## Modules
 
 - `ingestion/` - download and preprocess documents from SharePoint.
-- `retrieval/` - simple vector store and search utilities with reranking.
+- `retrieval/` - hashed vector store and retrieval utilities with reranking.
 - `llm/` - prompt handling and local model loading.
 - `memory/` - conversation history logging and search.
 - `api_server.py` - FastAPI application exposing `/query` and `/generate`.
 - `ui/` - minimal chat frontend with conversation view.
+- Embeddings use a lightweight word hashing scheme so no external model downloads are required.
+
+## Dummy SharePoint client
+
+The repository includes `DummySharePointClient` which provides static document
+URLs like `https://sharepoint.example.com/docs/doc1.txt`. The dummy client
+returns placeholder bytes for these URLs so the ingestion pipeline can be tested
+without real SharePoint credentials.

--- a/ingestion/file_parsers.py
+++ b/ingestion/file_parsers.py
@@ -61,7 +61,11 @@ def extract_text(file_path: Path) -> str:
     raise ValueError(f"Unsupported file type: {file_path}")
 
 
-def chunk_text(text: str, chunk_size: int = 500) -> Iterable[str]:
-    """Yield fixed-size chunks from text."""
-    for i in range(0, len(text), chunk_size):
-        yield text[i : i + chunk_size]
+def chunk_text(text: str, chunk_size: int = 200, overlap: int = 50) -> Iterable[str]:
+    """Yield overlapping word chunks from text."""
+    words = text.split()
+    start = 0
+    while start < len(words):
+        end = start + chunk_size
+        yield " ".join(words[start:end])
+        start += chunk_size - overlap

--- a/ingestion/sharepoint_client.py
+++ b/ingestion/sharepoint_client.py
@@ -34,3 +34,19 @@ class SharePointClient:
                 time.sleep(poll_interval)
             except Exception as e:
                 print(f"SharePoint watch error: {e}")
+
+
+class DummySharePointClient(SharePointClient):
+    """Client returning canned data for testing."""
+
+    def __init__(self) -> None:
+        super().__init__("https://sharepoint.example.com", {})
+
+    def list_documents(self) -> List[str]:
+        return [
+            "https://sharepoint.example.com/docs/doc1.txt",
+            "https://sharepoint.example.com/docs/doc2.txt",
+        ]
+
+    def download_document(self, url: str) -> bytes:
+        return b"Dummy document contents for " + url.encode()

--- a/memory/memory_index.py
+++ b/memory/memory_index.py
@@ -2,7 +2,7 @@
 
 from typing import List
 
-from retrieval.vector_store import VectorStore, VectorRecord
+from retrieval.vector_store import VectorStore, VectorRecord, embed_text
 
 
 class MemoryIndex:
@@ -13,5 +13,5 @@ class MemoryIndex:
         self.store.add(text=text, metadata=metadata)
 
     def search(self, query: str, top_k: int = 3) -> List[VectorRecord]:
-        vector = [0.0]
+        vector = embed_text(query)
         return self.store.query(vector, top_k=top_k)

--- a/retrieval/ranker.py
+++ b/retrieval/ranker.py
@@ -2,9 +2,17 @@
 
 from typing import List
 
-from .vector_store import VectorRecord
+from .vector_store import VectorRecord, embed_text
 
 
 def rerank(candidates: List[VectorRecord], query: str) -> List[VectorRecord]:
-    """Return reranked results (no-op placeholder)."""
-    return candidates
+    """Rerank candidates using cosine similarity to the query."""
+    if not candidates:
+        return []
+    qvec = embed_text(query)
+    scored = []
+    for rec in candidates:
+        dot = sum(q * r for q, r in zip(qvec, rec.vector))
+        scored.append((float(dot), rec))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [r for _, r in scored]

--- a/retrieval/search.py
+++ b/retrieval/search.py
@@ -2,7 +2,7 @@
 
 from typing import List
 
-from .vector_store import VectorStore, VectorRecord
+from .vector_store import VectorStore, VectorRecord, embed_text
 from .ranker import rerank
 
 
@@ -22,4 +22,4 @@ class Searcher:
             raise RuntimeError(f"Search failed: {e}") from e
 
     def _embed(self, text: str) -> List[float]:
-        return [0.0]
+        return embed_text(text)

--- a/retrieval/vector_store.py
+++ b/retrieval/vector_store.py
@@ -1,7 +1,23 @@
-"""Simple in-memory vector store placeholder."""
+"""Simple in-memory vector store with hashed embeddings."""
 
 from dataclasses import dataclass
-from typing import Any, List, Sequence
+from typing import List, Sequence
+
+import math
+
+DIM = 50
+
+
+def embed_text(text: str) -> List[float]:
+    """Naively hash words into a fixed-size vector."""
+    vec = [0.0] * DIM
+    for word in text.lower().split():
+        idx = hash(word) % DIM
+        vec[idx] += 1.0
+    norm = math.sqrt(sum(v * v for v in vec))
+    if norm:
+        vec = [v / norm for v in vec]
+    return vec
 
 
 @dataclass
@@ -19,15 +35,24 @@ class VectorStore:
 
     def add(self, text: str, metadata: dict) -> None:
         """Add a record to the store."""
-        vector = self._embed(text)
+        vector = embed_text(text)
         self.records.append(VectorRecord(text, vector, metadata))
 
     def query(self, vector: Sequence[float], top_k: int = 5) -> List[VectorRecord]:
-        """Return top_k similar records (naive)."""
+        """Return top_k similar records using cosine similarity."""
         if top_k <= 0:
             raise ValueError("top_k must be positive")
-        return self.records[:top_k]
+
+        if not self.records:
+            return []
+
+        qvec = vector
+        sims = []
+        for rec in self.records:
+            dot = sum(q * r for q, r in zip(qvec, rec.vector))
+            sims.append((float(dot), rec))
+        sims.sort(key=lambda x: x[0], reverse=True)
+        return [r for _, r in sims[:top_k]]
 
     def _embed(self, text: str) -> List[float]:
-        """Placeholder embedding function."""
-        return [0.0]
+        return embed_text(text)


### PR DESCRIPTION
## Summary
- implement hashed vector embeddings and cosine search
- add dummy SharePoint client for ingest tests
- update document chunking for overlap
- update README with new details

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
from ingestion.index_updater import IndexUpdater
from ingestion.sharepoint_client import DummySharePointClient
from retrieval.vector_store import VectorStore

client = DummySharePointClient()
store = VectorStore()
indexer = IndexUpdater(client, store)
indexer.ingest(client.list_documents())
print('records', len(store.records))
PY
`
- `python - <<'PY'
from retrieval.search import Searcher
from retrieval.vector_store import VectorStore
store = VectorStore()
store.add('the quick brown fox jumps over the lazy dog', {'source':'s1'})
store.add('lorem ipsum dolor sit amet', {'source':'s2'})
searcher = Searcher(store)
print(searcher.search('quick dog', top_k=1)[0].metadata['source'])
PY
`

------
https://chatgpt.com/codex/tasks/task_e_688602acc75483289ff1c4714fe93f16