### PR TITLE
Enhance prompt construction with source citations

### DIFF
--- a/llm/generator.py
+++ b/llm/generator.py
@@ -3,24 +3,31 @@
 from pathlib import Path
 from typing import Any, Dict, List
 
-from jinja2 import Template
-
 from .model_loader import load_model
 
 
 PROMPT_PATH = Path(__file__).with_name("prompt_template.txt")
 
 
-def build_prompt(context: str, question: str) -> str:
-    template = Template(PROMPT_PATH.read_text())
-    return template.render(context=context, question=question)
+def build_prompt(docs: List[Dict[str, str]], question: str) -> str:
+    """Render the prompt with numbered document excerpts."""
+    template = PROMPT_PATH.read_text()
+    lines = [template.splitlines()[0]]
+    for doc in docs:
+        lines.append(f"[{doc['index']}] {doc['title']} より抜粋:")
+        lines.append(f'"{doc["text"]}"')
+    lines.append("")
+    lines.append(f"ユーザーの質問: {question}")
+    lines.append("")
+    lines.append("回答:")
+    return "\n".join(lines)
 
 
-def generate_answer(context_docs: List[str], question: str, model_name: str) -> str:
+def generate_answer(docs: List[Dict[str, str]], question: str, model_name: str) -> str:
     """Generate an answer from context documents."""
 
     model = load_model(model_name)
-    prompt = build_prompt("\n".join(context_docs), question)
+    prompt = build_prompt(docs, question)
     # placeholder inference using local model
     return f"[Model output for] {prompt}"
 
@@ -28,7 +35,10 @@ def generate_answer(context_docs: List[str], question: str, model_name: str) -> 
 def generate_with_citations(records: List[Dict[str, Any]], question: str, model_name: str) -> Dict[str, Any]:
     """Generate answer and include source citations."""
 
-    docs = [r["text"] for r in records]
+    docs = [
+        {"index": i + 1, "title": r.get("source", ""), "text": r["text"]}
+        for i, r in enumerate(records)
+    ]
     answer = generate_answer(docs, question, model_name)
-    sources = [r.get("source") for r in records if r.get("source")]
+    sources = {str(d["index"]): d["title"] for d in docs if d["title"]}
     return {"answer": answer, "sources": sources}

--- a/llm/prompt_template.txt
+++ b/llm/prompt_template.txt
@@ -1,6 +1,1 @@
-Answer the question based on the context.
-
-Context:
-{{ context }}
-
-Question: {{ question }}
+あなたは社内文書に詳しいアシスタントです。以下の情報を参考にユーザーの質問に答えてください。提供情報に無い内容は答えないでください。回答では参照元を番号付きで示してください。例: [1]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from llm.generator import build_prompt, generate_with_citations
+
+
+def test_build_prompt_basic():
+    docs = [
+        {"index": 1, "title": "Doc1", "text": "foo bar"},
+        {"index": 2, "title": "Doc2", "text": "baz"},
+    ]
+    prompt = build_prompt(docs, "質問は?")
+    assert "Doc1" in prompt and "foo bar" in prompt
+    assert "質問は?" in prompt
+
+
+def test_generate_with_citations_mapping():
+    records = [
+        {"text": "chunk1", "source": "docA"},
+        {"text": "chunk2", "source": "docB"},
+    ]
+    res = generate_with_citations(records, "q", model_name="dummy")
+    assert res["sources"] == {"1": "docA", "2": "docB"}


### PR DESCRIPTION
## Summary
- replace Jinja2 templating with lightweight string based prompt builder
- add citation friendly prompt template
- return numbered source mapping from `generate_with_citations`
- test prompt building and citation mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68860bc8ad8c832892b9b3ba02529969